### PR TITLE
Fixing lexer initialization

### DIFF
--- a/src/frontend.ml
+++ b/src/frontend.ml
@@ -15,7 +15,7 @@ let usage =
 
 exception Abort_parsing
 
-let () = Lexer.init ()
+let () = Lexer_raw.init ()
 
 let oprintf oc fmt =
   Format.fprintf (Format.formatter_of_out_channel oc) fmt

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -44,7 +44,7 @@ let specs = [
 
 let () = Arg.parse specs (fun name -> opt_infile := Some name) usage
 
-let () = Lexer.init ()
+let () = Lexer_raw.init ()
 
 module Grammar = MenhirSdk.Cmly_read.FromString(Interpreter_data)
 module Interpreter = Lrgrep_interpreter.Make(Grammar)()


### PR DESCRIPTION
Seems like we need to call the `Lexer_raw` version of init